### PR TITLE
Upgrade to 5.2.1 and stricter pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.0" %}
+{% set version = "5.2.1" %}
 {% set name = "fplll" %}
 
 package:
@@ -8,13 +8,14 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/fplll/fplll/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 75e17fcaa4fc5fdddbe6eb42aca5f38c4c169a4b52756e74fbe2d1769737ac9c
+  sha256: e38e3f8f14d5dbf46aab66d6c12f5973d4b12b72832161ed1491e8e925de4816
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   run_exports:
-    - {{ pin_subpackage('fplll', max_pin='x.x') }}
+    # fplll had a breaking change in the 5.2.0 to 5.2.1 upgrade, so it's best to be strict about pinning.
+    - {{ pin_subpackage('fplll', max_pin='x.x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
If I understand https://github.com/fplll/fplll/pull/326/files correctly, they
changed how dot_product gets called in the 5.2.0 → 5.2.1 upgrade. So we should
pin more strictly here.